### PR TITLE
Fix tupas customer name encoding issue

### DIFF
--- a/modules/tupas_registration/tests/src/Functional/TupasRegistrationFunctionalTest.php
+++ b/modules/tupas_registration/tests/src/Functional/TupasRegistrationFunctionalTest.php
@@ -79,7 +79,8 @@ class TupasRegistrationFunctionalTest extends TupasSessionFunctionalBase {
     $this->drupalLogout();
 
     $this->loginUsingTupas([
-      'B02K_CUSTNAME' => 'Anne Testaaja',
+      // Test special characters.
+      'B02K_CUSTNAME' => 'Anné Testääjå',
       'B02K_CUSTID' => '654321-211A',
     ]);
     // Make sure username is hidden.
@@ -92,7 +93,7 @@ class TupasRegistrationFunctionalTest extends TupasSessionFunctionalBase {
     // the tupas service.
     $title = $this->getSession()->getPage()->find('css', 'h1');
     $this->assertTrue(mb_strlen($title->getText()), 10);
-    $this->assertEquals($title->getText(), 'Anne Testaaja');
+    $this->assertEquals($title->getText(), 'Anné Testääjå');
   }
 
   /**

--- a/modules/tupas_session/src/Controller/SessionController.php
+++ b/modules/tupas_session/src/Controller/SessionController.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\tupas_session\Controller;
 
+use Drupal\Component\Utility\Unicode;
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\Url;
 use Drupal\tupas\Entity\TupasBank;
@@ -177,10 +178,12 @@ class SessionController extends ControllerBase {
         ->dispatch(SessionEvents::CUSTOMER_ID_ALTER, new CustomerIdAlterEvent($hashed_id, [
           'raw' => $request->query->all(),
         ]));
+      // Name will be sent Latin1 encoded and urlencoded.
+      $name = Unicode::convertToUtf8(urldecode($request->query->get('B02K_CUSTNAME')), 'ISO-8859-1');
       // Start tupas session.
       $this->sessionManager->start($transaction_id, $dispatched_data->getCustomerId(), [
         'bank' => $bank->id(),
-        'name' => $request->query->get('B02K_CUSTNAME'),
+        'name' => $name,
       ]);
       // Allow redirect path to be customized.
       $redirect_data = new RedirectAlterEvent('<front>', $request->query->all(), $this->t('TUPAS authentication succesful.'));

--- a/modules/tupas_session/tests/src/Functional/TupasSessionFunctionalBase.php
+++ b/modules/tupas_session/tests/src/Functional/TupasSessionFunctionalBase.php
@@ -51,6 +51,9 @@ abstract class TupasSessionFunctionalBase extends BrowserTestBase {
       'B02K_CUSTTYPE' => '01',
     ];
     $return_values = array_merge($return_values, $overrides);
+    // Customer name will be in Latin1 charset and urlencoded by the
+    // tupas service.
+    $return_values['B02K_CUSTNAME'] = urlencode(mb_convert_encoding($return_values['B02K_CUSTNAME'], 'ISO-8859-1'));
 
     foreach ($return_values as $value) {
       $macstring[] = $value;


### PR DESCRIPTION
TUPAS service will send customer name urlencoded and in Latin1 charset and will cause issues with charset validation.